### PR TITLE
Fix dispatchCommand API to support any JSON-serializable input and string types

### DIFF
--- a/libreoffice-core/desktop/wasm/shared.ts
+++ b/libreoffice-core/desktop/wasm/shared.ts
@@ -85,7 +85,7 @@ export type DocumentWithViewMethods = {
   unsubscribe(callbackType: CallbackType): void;
   dispatchCommand(
     command: string,
-    args?: string,
+    args?: any,
     notifyWhenFinished?: boolean
   ): void;
   removeText(charsBefore: number, charsAfter: number): void;

--- a/libreoffice-core/desktop/wasm/worker.ts
+++ b/libreoffice-core/desktop/wasm/worker.ts
@@ -343,11 +343,16 @@ const handler: AsyncMessage = {
     ref: DocumentRef,
     viewId: ViewId,
     command: string,
-    args?: string,
+    args?: any,
     notifyWhenFinished?: boolean
   ): Promise<void> {
     await lokPromise;
-    byRef(ref)?.dispatchCommand(viewId, command, args, notifyWhenFinished);
+    byRef(ref)?.dispatchCommand(
+      viewId,
+      command,
+      typeof args === 'string' ? args : JSON.stringify(args),
+      notifyWhenFinished
+    );
   },
   removeText: async function (
     ref: DocumentRef,
@@ -356,7 +361,12 @@ const handler: AsyncMessage = {
     charsAfter: number
   ): Promise<void> {
     await lokPromise;
-    byRef(ref)?.removeText(viewId, 0 /* window id is pretty much always 0 (the default window) */, charsBefore, charsAfter);
+    byRef(ref)?.removeText(
+      viewId,
+      0 /* window id is pretty much always 0 (the default window) */,
+      charsBefore,
+      charsAfter
+    );
   },
   setClientVisibleArea: async function (
     ref: DocumentRef,


### PR DESCRIPTION
While I was reviewing your PR, I realized I forgot to implement this.