### PR TITLE
Fix duplicated tiles and missing tile errors when the tile pool is exhausted [MACRO-2197]

### DIFF
--- a/libreoffice-core/desktop/wasm/webgl2_draw_image.ts
+++ b/libreoffice-core/desktop/wasm/webgl2_draw_image.ts
@@ -69,12 +69,12 @@ export function createTexturePool(
 ): TexturePool {
   const pool = new Array(size);
   const freeStack = new Array(size);
-  let freeStackHead = 0;
+  let freeStackHead = size - 1;
   function pushFree(i: number) {
-    freeStack[freeStackHead--] = i;
+    freeStack[++freeStackHead] = i;
   }
   function popFree() {
-    return freeStack[freeStackHead++];
+    return freeStack[freeStackHead--];
   }
   function acquire(): PooledTexture | undefined {
     const i = popFree();


### PR DESCRIPTION
To test the fix, scroll to the bottom of a document with over 80 pages or just hold down a letter key for about 10 seconds