### PR TITLE
CHG fix QueryState api in wasm_extensions

### DIFF
--- a/qa-env/src/App.tsx
+++ b/qa-env/src/App.tsx
@@ -20,9 +20,6 @@ async function fileOpen(files: FileList | null) {
     cleanup(oldDoc);
   }
   const doc = await loadDocument(name, blob);
-  doc?.getCommandValues(".uno:PageOrientation").then((value) => {
-    console.log(value);
-    })
   if (!doc) {
     console.error('failure!');
     return;

--- a/qa-env/src/App.tsx
+++ b/qa-env/src/App.tsx
@@ -20,6 +20,9 @@ async function fileOpen(files: FileList | null) {
     cleanup(oldDoc);
   }
   const doc = await loadDocument(name, blob);
+  doc?.getCommandValues(".uno:PageOrientation").then((value) => {
+    console.log(value);
+    })
   if (!doc) {
     console.error('failure!');
     return;


### PR DESCRIPTION
looks like in 24.04 they changed the `QueryState` api to take a `SfxPoolItemHolder` instead of a `SfxPoolItem`
