### PR TITLE
Move zoom functionality out of App.tsx and into OfficeDocument.tsx

### DIFF
--- a/libreoffice-core/desktop/wasm/shared.ts
+++ b/libreoffice-core/desktop/wasm/shared.ts
@@ -109,8 +109,7 @@ export type DocumentWithViewMethods = {
 
   setScrollTop(yPx: number): number;
   setVisibleHeight(heightPx: number): void;
-
-  setZoom(scale: number, dpi: number, yTop: number): void;
+  setZoom(scale: number, dpi: number): void;
 
   /** TODO: implement, used to set a new scale or set a new offscreen cavnas */
   resetRendering(

--- a/libreoffice-core/desktop/wasm/tile_renderer_worker.ts
+++ b/libreoffice-core/desktop/wasm/tile_renderer_worker.ts
@@ -131,10 +131,6 @@ function zoom(in_scale: number, in_dpi: number) {
   scheduledHeightTwips = activeCanvas.height * scaledTwips;
   scheduledWidthPx = docWidthTwips / scaledTwips;
 
-  // TODO: @synoet - after making the scroll area responsive (see zoom.ts), this shouldn't be necessary since a scroll event should fire
-  // Update the top position to the new scale
-  scheduledTopTwips = in_y * scaledTwips;
-
   // Set this as a reference for the new position for the next scroll event
   renderedTileTop = Math.floor(scheduledTopTwips / tileDimTwips);
 
@@ -152,7 +148,7 @@ function initialize(data: ToTileRenderer & { t: 'i' }) {
 
   scale = data.s;
   dpi = data.dpi;
-  zoom(data.s, dpi, data.y);
+  zoom(data.s, dpi);
   scheduledTopTwips = data.y * scaledTwips;
 
   pendingStateChange = true;

--- a/libreoffice-core/desktop/wasm/tile_renderer_worker.ts
+++ b/libreoffice-core/desktop/wasm/tile_renderer_worker.ts
@@ -104,7 +104,7 @@ onmessage = ({ data }: { data: ToTileRenderer }) => {
       if (zoomResetTimeout) clearTimeout(zoomResetTimeout);
 
       idleAreaPaint = false;
-      zoom(data.s, data.d, data.y);
+      zoom(data.s, data.d);
 
       // Ensure we debounce a reset in combination with shouldStopPaint
       zoomResetTimeout = setTimeout(() => {
@@ -117,7 +117,7 @@ onmessage = ({ data }: { data: ToTileRenderer }) => {
   }
 };
 
-function zoom(in_scale: number, in_dpi: number, in_y: number) {
+function zoom(in_scale: number, in_dpi: number) {
   docWidthTwips = Atomics.load(d.docWidthTwips, 0);
   docHeightTwips = Atomics.load(d.docHeightTwips, 0);
 
@@ -131,6 +131,7 @@ function zoom(in_scale: number, in_dpi: number, in_y: number) {
   scheduledHeightTwips = activeCanvas.height * scaledTwips;
   scheduledWidthPx = docWidthTwips / scaledTwips;
 
+  // TODO: @synoet - after making the scroll area responsive (see zoom.ts), this shouldn't be necessary since a scroll event should fire
   // Update the top position to the new scale
   scheduledTopTwips = in_y * scaledTwips;
 

--- a/libreoffice-core/desktop/wasm/worker.ts
+++ b/libreoffice-core/desktop/wasm/worker.ts
@@ -414,13 +414,11 @@ const handler: AsyncMessage = {
     viewId: ViewId,
     scale: number,
     dpi: number,
-    yTop: number,
   ): Promise<void> {
     tileRenderer[ref][viewId]?.postMessage({
       t: 'z',
       s: scale,
       d: dpi,
-      y: yTop,
     } as ToTileRenderer);
   },
 };

--- a/qa-env/src/App.tsx
+++ b/qa-env/src/App.tsx
@@ -3,11 +3,11 @@ import { CallbackType } from '@lok/lok_enums';
 import type { DocumentClient } from '@lok/shared';
 import { Show, createSignal, onCleanup } from 'solid-js';
 import './App.css';
-import { OfficeDocument, setCanvasObjectFit } from './OfficeDocument/OfficeDocument';
+import { OfficeDocument } from './OfficeDocument/OfficeDocument';
 import { cleanup } from './OfficeDocument/cleanup';
 import { IS_MAC } from './OfficeDocument/isMac';
 import { Shortcut } from './OfficeDocument/vclKeys';
-import { updateZoom } from './OfficeDocument/zoom';
+import { ZOOM_STEP, updateZoom } from './OfficeDocument/zoom';
 import { downloadFile } from './utils';
 
 const [loading, setLoading] = createSignal(false);
@@ -43,9 +43,9 @@ async function fileOpen(files: FileList | null) {
 }
 async function saveAsPDF(doc: DocumentClient | null) {
   if (!doc) return;
-  const buffer = await doc.save("pdf")
-  downloadFile("Pdf Export.pdf", buffer, "application/pdf");
-};
+  const buffer = await doc.save('pdf');
+  downloadFile('Pdf Export.pdf', buffer, 'application/pdf');
+}
 
 const MOD = IS_MAC ? 'cmd' : 'ctrl';
 const ignoredShortcuts: Shortcut[] = [
@@ -59,23 +59,7 @@ const ignoredShortcuts: Shortcut[] = [
   },
 ];
 
-/// This gives us good behavior until the render actually finishes
-/// Cover on Zoom In, will stretch the image to fit as 
-/// the canvas size changes 
-const ZOOM_IN_CANVAS_FIT = "cover";
-/// This gives us good behavior until the render actually finishes
-/// Contain on Zoom Out, squeezes the image to fit as
-/// the canvas size changes 
-const ZOOM_OUT_CANVAS_FIT = "contain";
-
-// Helpful to step by 1/8 because of 256 tile size
-// When clipping the zoom we are more likely to get
-// a full tile
-const ZOOM_STEP = .125;
-
-let zoomTimeout: ReturnType<typeof setTimeout> ;
-
-export const [isZooming, setIsZooming] = createSignal(false);
+let zoomTimeout: ReturnType<typeof setTimeout>;
 
 function registerGlobalKeys() {
   async function callback(e: KeyboardEvent) {
@@ -83,13 +67,11 @@ function registerGlobalKeys() {
     switch (e.key) {
       case '=':
         e.preventDefault();
-        setCanvasObjectFit(ZOOM_IN_CANVAS_FIT)
         if (zoomTimeout) clearTimeout(zoomTimeout);
         zoomTimeout = setTimeout(() => updateZoom(getDocThrows, ZOOM_STEP));
         break;
       case '-':
         e.preventDefault();
-        setCanvasObjectFit(ZOOM_OUT_CANVAS_FIT)
         if (zoomTimeout) clearTimeout(zoomTimeout);
         zoomTimeout = setTimeout(() => updateZoom(getDocThrows, -ZOOM_STEP));
         break;
@@ -97,23 +79,17 @@ function registerGlobalKeys() {
   }
 
   async function wheelCallback(e: WheelEvent) {
-    if (IS_MAC ? !e.metaKey : !e.ctrlKey) return;
-    
-    const isAccelerated = IS_MAC ? e.metaKey : e.ctrlKey;
-
-    if (!isAccelerated) return;
+    if (!e.ctrlKey) return;
 
     e.preventDefault();
     e.stopPropagation();
 
     // Scroll Up = Zoom In
     if (e.deltaY < 0) {
-      setCanvasObjectFit(ZOOM_IN_CANVAS_FIT);
       if (zoomTimeout) clearTimeout(zoomTimeout);
       zoomTimeout = setTimeout(() => updateZoom(getDocThrows, ZOOM_STEP));
-    // Scroll Down = Zoom In
+      // Scroll Down = Zoom In
     } else if (e.deltaY > 0) {
-      setCanvasObjectFit(ZOOM_OUT_CANVAS_FIT)
       if (zoomTimeout) clearTimeout(zoomTimeout);
       zoomTimeout = setTimeout(() => updateZoom(getDocThrows, -ZOOM_STEP));
     }
@@ -121,15 +97,13 @@ function registerGlobalKeys() {
 
   document.addEventListener('keydown', callback);
   // By default wheel events are passive and annot be prevented
-  document.addEventListener('wheel', wheelCallback, {passive: false})
+  document.addEventListener('wheel', wheelCallback, { passive: false });
 
   onCleanup(() => {
     document.removeEventListener('keydown', callback);
     document.removeEventListener('wheel', wheelCallback);
   });
 }
-
-export const [scrollAreaRef, setScrollAreaRef] = createSignal<HTMLDivElement | null>(null);
 
 function App() {
   registerGlobalKeys();
@@ -149,10 +123,8 @@ function App() {
         />
       </div>
       <Show when={getDoc()}>
-        <div class = "h-[70px] border-b border border-gray-300 flex items-center bg-gray-200 px-2">
-          <button onClick={() => saveAsPDF(getDoc())}>
-            Save As PDF
-          </button>
+        <div class="h-[70px] border-b border border-gray-300 flex items-center bg-gray-200 px-2">
+          <button onClick={() => saveAsPDF(getDoc())}>Save As PDF</button>
         </div>
       </Show>
       <Show when={loading()}>
@@ -161,7 +133,7 @@ function App() {
         </div>
       </Show>
       <Show when={getDoc()} keyed>
-        <OfficeDocument doc={getDoc()!} ignoreShortcuts={ignoredShortcuts} scrollAreaRef={setScrollAreaRef}/>
+        <OfficeDocument doc={getDoc()!} ignoreShortcuts={ignoredShortcuts} />
       </Show>
     </>
   );

--- a/qa-env/src/OfficeDocument/OfficeDocument.tsx
+++ b/qa-env/src/OfficeDocument/OfficeDocument.tsx
@@ -133,6 +133,11 @@ export function OfficeDocument(props: Props) {
     const zoom = getZoom();
     return docSizeTwips()?.map((i) => twipsToCssPx(i, zoom));
   };
+
+  createEffect(() => {
+    console.log(docSizePx())
+  })
+
   const rectsPx = () => {
     const [getZoom] = getOrCreateZoomSignal(() => props.doc);
     const zoom = getZoom();
@@ -209,20 +214,35 @@ export function OfficeDocument(props: Props) {
     return result;
   });
 
+  const [scrollPos, setScrollPos] = createSignal<{x: number, y: number}>();
+
+  /// Make the scroll responsive to the changing zoom level
+  /// Only update scroll when zoom has actually changed
+  createEffect((prev: number | undefined) => {
+    let newZoom = getZoom();
+    if (!prev || prev === newZoom) return newZoom; 
+    const pos = scrollPos();
+    if (!pos) return newZoom;
+
+    const scalePos = (p: number) =>
+      Math.floor(((p / (prev || 1) * newZoom)));
+
+    const newX = scalePos(pos.x);
+    const newY = scalePos(pos.y);
+
+    if (!scrollAreaRef) return newZoom;
+
+    scrollAreaRef.scrollLeft = newX;
+    scrollAreaRef.scrollTop = newY;
+
+    setScrollPos({x: newX, y: newY});
+    return newZoom;
+  }, getZoom())
+
+
   const handleScroll = frameThrottle(async (yPx, xPx) => {
+    setScrollPos({x: xPx, y: yPx});
     handleScroll.cancel();
-
-    // We still need to apply a transform to the
-    // canvas when zooming in/out without triggering
-    // a render that would be caused by the scroll event
-    if (isZooming()) {
-      const c = activeCanvas === 0 ? canvas0() : canvas1();
-      if (!c) return;
-      c.style.transform = `translate3d(-${xPx}px, -${Math.floor(yPx) % TILE_DIM_PX}px, 0)`;
-      setIsZooming(false);
-      return;
-    }
-
     const c0 = canvas0();
     const c1 = canvas1();
     if (!c0 || !c1) return;

--- a/qa-env/src/OfficeDocument/OfficeDocument.tsx
+++ b/qa-env/src/OfficeDocument/OfficeDocument.tsx
@@ -9,6 +9,7 @@ import {
   createSignal,
   onCleanup,
   onMount,
+  on,
 } from 'solid-js';
 import { CallbackType } from '@lok/lok_enums';
 import { ScrollArea } from './ScrollArea';
@@ -21,15 +22,18 @@ import { getOrCreateFocusedSignal } from './focus';
 import { frameThrottle } from './frameThrottle';
 import { getOrCreateZoomSignal } from './zoom';
 import { getOrCreateDPISignal } from './twipConversion';
-import { isZooming, setIsZooming } from '../App';
 
+// These give us good scaling behavior until the render actually finishes
+/** Cover on Zoom In, will stretch the image to fit as the canvas size changes */
+const ZOOM_IN_CANVAS_FIT = 'cover';
+/** Contain on Zoom Out, squeezes the image to fit as the canvas size changes */
+const ZOOM_OUT_CANVAS_FIT = 'contain';
 const OBSERVED_SIZE_DEBOUNCE = 100; //ms
 
 const BORDER_WIDTH = 1;
 
 interface Props extends Omit<JSX.HTMLAttributes<HTMLDivElement>, 'onScroll'> {
   doc: DocumentClient;
-  scrollAreaRef?: (ref: HTMLDivElement) => void;
   ignoreShortcuts?: Shortcut[];
 }
 
@@ -48,8 +52,6 @@ declare module 'solid-js' {
   }
 }
 false && observedSize; // workaround for "unused" function warning with Solid directives
-
-export const [canvasObjectFit, setCanvasObjectFit] = createSignal<"cover" | "contain" | "fill">("cover");
 
 function calcCanvasHeight(heightPx: number | undefined) {
   return heightPx
@@ -94,13 +96,13 @@ function scaleRectCssPx(rect: RectangleTwips, zoom: number): RectanglePx {
     y: twipsToCssPx(rect.y, zoom),
     height: twipsToCssPx(rect.height, zoom),
     width: twipsToCssPx(rect.width, zoom),
-  }
+  };
 }
 
 const didInitialRender = new WeakSet<DocumentClient>();
 
 export function OfficeDocument(props: Props) {
-
+  let scrollAreaRef: HTMLDivElement | undefined;
   /** TODO: add DPI observer and handle DPI change */
   /** TODO: add context loss for machine if left asleep */
   const [containerHeight, setContainerHeight] = createSignal<
@@ -123,23 +125,21 @@ export function OfficeDocument(props: Props) {
 
   createEffect(async () => {
     setDocSizeTwips(await props.doc.documentSize());
-    setRectsTwips(
-      await props.doc.partRectanglesTwips()
-    );
+    setRectsTwips(await props.doc.partRectanglesTwips());
   });
 
   const docSizePx = () => {
     const [getZoom] = getOrCreateZoomSignal(() => props.doc);
     const zoom = getZoom();
     return docSizeTwips()?.map((i) => twipsToCssPx(i, zoom));
-  }
+  };
   const rectsPx = () => {
     const [getZoom] = getOrCreateZoomSignal(() => props.doc);
     const zoom = getZoom();
     return rectsTwips()
-      ?.map(rect => scaleRectCssPx(rect, zoom))
+      ?.map((rect) => scaleRectCssPx(rect, zoom))
       .filter((rect) => rect.width && rect.height);
-  }
+  };
 
   createEffect(() => {
     const callback = async () => {
@@ -157,14 +157,26 @@ export function OfficeDocument(props: Props) {
     if (height) props.doc.setVisibleHeight(height);
   });
 
+  const [getZoom] = getOrCreateZoomSignal(() => props.doc);
+
+  const didZoomOut = createMemo(
+    on(
+      getZoom,
+      (zoom, lastZoom) => {
+        return lastZoom != null && zoom < lastZoom;
+      },
+      { defer: true }
+    ),
+    false
+  );
+
   createEffect(async () => {
     if (didInitialRender.has(props.doc)) return;
     const width = docSizePx()?.[0];
     const height = canvasHeight();
     const canvas0_ = canvas0();
     const canvas1_ = canvas1();
-    if (!width || !height || !canvas0_ || !canvas1_ || !props.doc)
-      return;
+    if (!width || !height || !canvas0_ || !canvas1_ || !props.doc) return;
     const [getZoom] = getOrCreateZoomSignal(() => props.doc);
     const zoom = getZoom();
     const getDpi = getOrCreateDPISignal();
@@ -200,7 +212,7 @@ export function OfficeDocument(props: Props) {
   const handleScroll = frameThrottle(async (yPx, xPx) => {
     handleScroll.cancel();
 
-    // We still need to apply a transform to the 
+    // We still need to apply a transform to the
     // canvas when zooming in/out without triggering
     // a render that would be caused by the scroll event
     if (isZooming()) {
@@ -209,7 +221,7 @@ export function OfficeDocument(props: Props) {
       c.style.transform = `translate3d(-${xPx}px, -${Math.floor(yPx) % TILE_DIM_PX}px, 0)`;
       setIsZooming(false);
       return;
-    };
+    }
 
     const c0 = canvas0();
     const c1 = canvas1();
@@ -227,10 +239,8 @@ export function OfficeDocument(props: Props) {
     }
   });
 
-
   return (
     <>
-
       <div
         class="flex flex-1 justify-center relative overflow-hidden"
         use:observedSize={[props.doc, setContainerHeight]}
@@ -241,7 +251,7 @@ export function OfficeDocument(props: Props) {
               ref={setCanvas0}
               class="absolute top-0 pointer-events-none"
               style={{
-                'object-fit': canvasObjectFit(),
+                'object-fit': didZoomOut() ? ZOOM_OUT_CANVAS_FIT : ZOOM_IN_CANVAS_FIT,
                 'object-position': 'top center',
                 'transform-origin': 'top center',
                 width: `${docSizePx()![0]}px`,
@@ -252,7 +262,7 @@ export function OfficeDocument(props: Props) {
               ref={setCanvas1}
               class="absolute top-0 pointer-events-none"
               style={{
-                'object-fit': canvasObjectFit(),
+                'object-fit': didZoomOut() ? ZOOM_OUT_CANVAS_FIT : ZOOM_IN_CANVAS_FIT,
                 'object-position': 'top center',
                 'transform-origin': 'top center',
                 width: `${docSizePx()![0]}px`,
@@ -265,7 +275,7 @@ export function OfficeDocument(props: Props) {
         <ScrollArea
           class="absolute top-0"
           onScroll={handleScroll}
-          ref={props.scrollAreaRef}
+          ref={scrollAreaRef}
         >
           {docSizePx() && (
             <div
@@ -283,21 +293,21 @@ export function OfficeDocument(props: Props) {
               }}
               oncapture:mousemove={(e: MouseEvent) => {
                 // Seems like on firefox the mousemove event object gets recycled
-                // We can't pass a ref of the event to frameThrottle because it 
+                // We can't pass a ref of the event to frameThrottle because it
                 // might get mutated / cleaned up by the time the callback gets invoked
                 // Instead copying over what we need instead of doing a full clone
                 const partialEvent: vclMouse.PartialMouseEvent = {
-                      buttons: e.buttons,
-                      offsetX: e.offsetX,
-                      offsetY: e.offsetY,
-                      shiftKey: e.shiftKey,
-                      altKey: e.altKey,
-                      metaKey: e.metaKey,
-                      ctrlKey: e.ctrlKey,
-                }
+                  buttons: e.buttons,
+                  offsetX: e.offsetX,
+                  offsetY: e.offsetY,
+                  shiftKey: e.shiftKey,
+                  altKey: e.altKey,
+                  metaKey: e.metaKey,
+                  ctrlKey: e.ctrlKey,
+                };
                 const callback = frameThrottle((evt) => {
-                    vclMouse.handleMouseMove(props.doc, evt);
-                })
+                  vclMouse.handleMouseMove(props.doc, evt);
+                });
 
                 callback(partialEvent);
               }}

--- a/qa-env/src/OfficeDocument/OfficeDocument.tsx
+++ b/qa-env/src/OfficeDocument/OfficeDocument.tsx
@@ -219,14 +219,12 @@ export function OfficeDocument(props: Props) {
       getZoom,
       (newZoom, prev) => {
         const pos = scrollPos();
-        if (!pos) return;
+        if (!pos || !scrollAreaRef) return;
 
         const scalePos = (p: number) => Math.floor((p / (prev || 1)) * newZoom);
 
         const newX = scalePos(pos.x);
         const newY = scalePos(pos.y);
-
-        if (!scrollAreaRef) return;
 
         scrollAreaRef.scrollLeft = newX;
         scrollAreaRef.scrollTop = newY;

--- a/qa-env/src/OfficeDocument/OfficeDocument.tsx
+++ b/qa-env/src/OfficeDocument/OfficeDocument.tsx
@@ -134,10 +134,6 @@ export function OfficeDocument(props: Props) {
     return docSizeTwips()?.map((i) => twipsToCssPx(i, zoom));
   };
 
-  createEffect(() => {
-    console.log(docSizePx())
-  })
-
   const rectsPx = () => {
     const [getZoom] = getOrCreateZoomSignal(() => props.doc);
     const zoom = getZoom();
@@ -214,34 +210,35 @@ export function OfficeDocument(props: Props) {
     return result;
   });
 
-  const [scrollPos, setScrollPos] = createSignal<{x: number, y: number}>();
+  const [scrollPos, setScrollPos] = createSignal<{ x: number; y: number }>();
 
   /// Make the scroll responsive to the changing zoom level
   /// Only update scroll when zoom has actually changed
-  createEffect((prev: number | undefined) => {
-    let newZoom = getZoom();
-    if (!prev || prev === newZoom) return newZoom; 
-    const pos = scrollPos();
-    if (!pos) return newZoom;
+  createEffect(
+    on(
+      getZoom,
+      (newZoom, prev) => {
+        const pos = scrollPos();
+        if (!pos) return;
 
-    const scalePos = (p: number) =>
-      Math.floor(((p / (prev || 1) * newZoom)));
+        const scalePos = (p: number) => Math.floor((p / (prev || 1)) * newZoom);
 
-    const newX = scalePos(pos.x);
-    const newY = scalePos(pos.y);
+        const newX = scalePos(pos.x);
+        const newY = scalePos(pos.y);
 
-    if (!scrollAreaRef) return newZoom;
+        if (!scrollAreaRef) return;
 
-    scrollAreaRef.scrollLeft = newX;
-    scrollAreaRef.scrollTop = newY;
+        scrollAreaRef.scrollLeft = newX;
+        scrollAreaRef.scrollTop = newY;
 
-    setScrollPos({x: newX, y: newY});
-    return newZoom;
-  }, getZoom())
-
+        setScrollPos({ x: newX, y: newY });
+      },
+      { defer: true }
+    )
+  );
 
   const handleScroll = frameThrottle(async (yPx, xPx) => {
-    setScrollPos({x: xPx, y: yPx});
+    setScrollPos({ x: xPx, y: yPx });
     handleScroll.cancel();
     const c0 = canvas0();
     const c1 = canvas1();
@@ -271,7 +268,9 @@ export function OfficeDocument(props: Props) {
               ref={setCanvas0}
               class="absolute top-0 pointer-events-none"
               style={{
-                'object-fit': didZoomOut() ? ZOOM_OUT_CANVAS_FIT : ZOOM_IN_CANVAS_FIT,
+                'object-fit': didZoomOut()
+                  ? ZOOM_OUT_CANVAS_FIT
+                  : ZOOM_IN_CANVAS_FIT,
                 'object-position': 'top center',
                 'transform-origin': 'top center',
                 width: `${docSizePx()![0]}px`,
@@ -282,7 +281,9 @@ export function OfficeDocument(props: Props) {
               ref={setCanvas1}
               class="absolute top-0 pointer-events-none"
               style={{
-                'object-fit': didZoomOut() ? ZOOM_OUT_CANVAS_FIT : ZOOM_IN_CANVAS_FIT,
+                'object-fit': didZoomOut()
+                  ? ZOOM_OUT_CANVAS_FIT
+                  : ZOOM_IN_CANVAS_FIT,
                 'object-position': 'top center',
                 'transform-origin': 'top center',
                 width: `${docSizePx()![0]}px`,

--- a/qa-env/src/OfficeDocument/zoom.ts
+++ b/qa-env/src/OfficeDocument/zoom.ts
@@ -50,23 +50,6 @@ export function updateZoom(
   const roundedZoom = Math.round((zoom() + offset) / Epsilon) * Epsilon;
   const newZoom = Math.min(MAX_ZOOM, Math.max(MIN_ZOOM, roundedZoom));
 
-  let newScrollTop: number = 0;
-
-  // TODO: @synoet - don't manipulate the scroll area inside of a setter,
-  // make it responsive and move this inside of OfficeDocument.tsx {
- 
-  // We need to adjust the scroll position manually
-  // to keep the relative position of the document the same
-  // after the zoom level changes
-  if (scrollArea) {
-    const scrollTop = scrollArea.scrollTop;
-    newScrollTop = scrollTop / zoom() * newZoom;
-    scrollArea.scrollTop =  newScrollTop
-  } else {
-    console.error(`tried to update zoom without scrollAreaRef`)
-  }
-  // TODO: }
-
   setZoom(doc, newZoom);
   return newZoom;
 }

--- a/qa-env/src/OfficeDocument/zoom.ts
+++ b/qa-env/src/OfficeDocument/zoom.ts
@@ -2,11 +2,13 @@ import { twipsToCssPx } from '@lok';
 import { DocumentClient } from '@lok/shared';
 import { Accessor, Signal, createSignal } from 'solid-js';
 import { getOrCreateDPISignal } from './twipConversion';
-import { scrollAreaRef, setIsZooming } from '../App';
 
 export const DEFAULT_ZOOM = 0.8;
 export const MAX_ZOOM = 3;
-export const MIN_ZOOM = 0.4;
+export const MIN_ZOOM = 0.375;
+
+// Stepping by 1/8th seems to keep text relatively crisp
+export const ZOOM_STEP = 0.125;
 
 const docZooms = new WeakMap<DocumentClient, Signal<number>>();
 
@@ -23,13 +25,14 @@ export function getOrCreateZoomSignal(
   return result;
 }
 
-export function setZoom(doc: Accessor<DocumentClient>, level: number, yTop: number) {
+export function setZoom(doc: Accessor<DocumentClient>, level: number) {
   const [, set] = getOrCreateZoomSignal(doc);
   const getDpi = getOrCreateDPISignal();
   const dpi = getDpi();
-  doc().setZoom(level, dpi, yTop);
+  doc().setZoom(level, dpi);
   set(level);
 }
+
 /**
  * @param offset offset from the current zoom level
  * @returns the new zoom level
@@ -44,13 +47,14 @@ export function updateZoom(
   offset: number
 ): number {
   const [zoom] = getOrCreateZoomSignal(doc);
-  setIsZooming(true);
   const roundedZoom = Math.round((zoom() + offset) / Epsilon) * Epsilon;
   const newZoom = Math.min(MAX_ZOOM, Math.max(MIN_ZOOM, roundedZoom));
 
-  const scrollArea = scrollAreaRef();
   let newScrollTop: number = 0;
 
+  // TODO: @synoet - don't manipulate the scroll area inside of a setter,
+  // make it responsive and move this inside of OfficeDocument.tsx {
+ 
   // We need to adjust the scroll position manually
   // to keep the relative position of the document the same
   // after the zoom level changes
@@ -61,8 +65,9 @@ export function updateZoom(
   } else {
     console.error(`tried to update zoom without scrollAreaRef`)
   }
+  // TODO: }
 
-  setZoom(doc, newZoom, newScrollTop);
+  setZoom(doc, newZoom);
   return newZoom;
 }
 
@@ -96,7 +101,7 @@ export async function zoomToFit(
       ? Math.min(DEFAULT_ZOOM, scaleFactor * zoom)
       : scaleFactor * zoom;
 
-  setZoom(doc, newZoom, scrollAreaRef()?.scrollTop ?? 0);
+  setZoom(doc, newZoom);
 
   return newZoom;
 }


### PR DESCRIPTION
@synoet Essentially, what needed to be cleaned up was:
- There needs to be a single source of truth and a clean cut divide between `App.tsx` and `OfficeDocument/*`: `App.tsx` triggers actions and consumes, but does not implement functionality. Think of App.tsx as the testing ground for using our implementation we will be providing in the monorepo.
- App.tsx will not be transferred into monorepo, implementation details of OfficeDocument should be self-contained.
- We should do our best to _never_ expose the DOM elements used inside of OfficeDocument, this means that the control for that element can have many sources of truth/actors that aren't aware of each other. This is a mistake we made in monorepo and it's led to a lot of problems.


Please see the changes for more context.

A fairly important piece to note is in `OfficeDocument.tsx`, `didZoomOut` is calculated in response to the signal and the appropriate object-fit is used as a result. This takes advantage of `on` providing the previous value for an explicit dependency and uses `{ defere: true }` to only do so when the value first changes:

``` typescript
const didZoomOut = createMemo(
  on(
    getZoom,
    (zoom, lastZoom) => {
      return lastZoom != null && zoom < lastZoom;
    },
    { defer: true }
  ),
  false
);
```

You'll need to handle the merge conflicts, but feel free to pick up from the branch directly. I can review the changes from this PR.