### PR TITLE
FIX initial cursor focus [MACRO-2427]

### DIFF
--- a/qa-env/src/OfficeDocument/InputHandler.tsx
+++ b/qa-env/src/OfficeDocument/InputHandler.tsx
@@ -66,14 +66,16 @@ export function InputHandler(props: Props) {
     }
   });
 
-  createEffect(() => {
-    if (focus()) {
+  createEffect<number[] | null>((prevPos) => {
+    if (focus() && (prevPos !== props.pos)) {
       input.focus();
       if (!isSelectionValid(input) || isCaretAtPreSpace(input)) {
         reset();
       }
     }
-  });
+
+    return props.pos;
+  }, null);
 
   function abortComposition() {
     reset(document.activeElement !== input);

--- a/qa-env/src/OfficeDocument/InputHandler.tsx
+++ b/qa-env/src/OfficeDocument/InputHandler.tsx
@@ -66,18 +66,14 @@ export function InputHandler(props: Props) {
     }
   });
 
-  createEffect<void, number[]>((prevPos) => {
-    // Only re-focus if the position has changed already
-    // and the document is focused
-    if (focus() && prevPos !== props.pos) {
+  createEffect(() => {
+    if (focus()) {
       input.focus();
       if (!isSelectionValid(input) || isCaretAtPreSpace(input)) {
         reset();
       }
     }
-
-    return props.pos;
-  }, props.pos);
+  });
 
   function abortComposition() {
     reset(document.activeElement !== input);


### PR DESCRIPTION
Initial value needs to be null otherwise the first focus will fail since `props.pos` is the initial value and `props.pos` is also the current value.