### PR TITLE
FIX blurry canvas rendering [MACRO-2440]

### DIFF
--- a/libreoffice-core/desktop/wasm/tile_renderer_worker.ts
+++ b/libreoffice-core/desktop/wasm/tile_renderer_worker.ts
@@ -134,7 +134,7 @@ class RenderedView {
     this.tileTwips = tileTwips;
     this.paintedTile = paintedTile;
     this.activeCanvas = canvases[0];
-    this.ctx = this.activeCanvas.getContext('2d');
+    this.ctx = getContext(this.activeCanvas);
     this.pendingFullPaint = pendingFullPaint;
 
     this.zoom(scale, dpi);
@@ -185,7 +185,7 @@ class RenderedView {
       this.didScroll = true;
       this.activeCanvasIndex ^= 1;
       this.activeCanvas = this.canvases[this.activeCanvasIndex];
-      this.ctx = this.activeCanvas.getContext('2d');
+      this.ctx = getContext(this.activeCanvas);
       setState(RenderState.IDLE, this.viewId);
       if (!running) stateMachine();
     } else {
@@ -1084,6 +1084,14 @@ function trimmedMean(input: number[]): number {
   const sum = trimmedArray.reduce((acc, val) => acc + val, 0);
 
   return sum / trimmedArray.length;
+}
+
+function getContext(canvas: OffscreenCanvas) {
+  let ctx = canvas.getContext("2d");
+  // default is true, which makes things blurry
+  //https://developer.mozilla.org/en-US/docs/Web/API/CanvasRenderingContext2D/imageSmoothingEnabled
+  ctx.imageSmoothingEnabled = false;
+  return ctx;
 }
 
 function addBorder(imageData: ImageData) {

--- a/qa-env/src/OfficeDocument/OfficeDocument.tsx
+++ b/qa-env/src/OfficeDocument/OfficeDocument.tsx
@@ -24,8 +24,9 @@ import { getOrCreateZoomSignal } from './zoom';
 import { getOrCreateDPISignal } from './twipConversion';
 
 // These give us good scaling behavior until the render actually finishes
-/** Cover on Zoom In, will stretch the image to fit as the canvas size changes */
-const ZOOM_IN_CANVAS_FIT = 'cover';
+
+/** 'cover' is ideal for zoom_in, however it causes issues with pixelation. */
+const ZOOM_IN_CANVAS_FIT = 'contain';
 /** Contain on Zoom Out, squeezes the image to fit as the canvas size changes */
 const ZOOM_OUT_CANVAS_FIT = 'contain';
 const OBSERVED_SIZE_DEBOUNCE = 100; //ms
@@ -272,6 +273,7 @@ export function OfficeDocument(props: Props) {
                   ? ZOOM_OUT_CANVAS_FIT
                   : ZOOM_IN_CANVAS_FIT,
                 'object-position': 'top center',
+                'image-rendering': 'crisp-edges',
                 'transform-origin': 'top center',
                 width: `${docSizePx()![0]}px`,
                 height: `${canvasHeight()!}px`,
@@ -285,6 +287,7 @@ export function OfficeDocument(props: Props) {
                   ? ZOOM_OUT_CANVAS_FIT
                   : ZOOM_IN_CANVAS_FIT,
                 'object-position': 'top center',
+                'image-rendering': 'crisp-edges',
                 'transform-origin': 'top center',
                 width: `${docSizePx()![0]}px`,
                 height: `${canvasHeight()}px`,


### PR DESCRIPTION
Seems like there are two issues:

1. `imageSmoothingEnabled` is set to true by default which tries to smoothen text, making it look more blurry;
2. Apparently setting an `object-fit: cover` can cause pixelation during downscaling. I've switched it to contain which is not as smooth but gets the job done. [(Stack Overflow - Cover Issue)](https://stackoverflow.com/questions/31910043/html5-canvas-drawimage-draws-image-blurry)

#### Before:
![image](https://github.com/coparse-inc/lok-wasm/assets/10552019/4cccf1ec-268c-400c-a22f-61e2b9491594)


#### After:
![image](https://github.com/coparse-inc/lok-wasm/assets/10552019/b6214f15-339e-49ad-80ac-a2b6f7ac53dc)

