### PR TITLE
FIX Redo Keybinding / shift handling [MACRO-2475]

### DIFF
--- a/qa-env/src/OfficeDocument/vclKeys.ts
+++ b/qa-env/src/OfficeDocument/vclKeys.ts
@@ -275,10 +275,7 @@ export function createKeyHandler(
       // simple key down
       if (
         modifiers &&
-        evt.type === 'keydown' &&
-        (!evt.shiftKey ||
-          // don't override scrolling when out of focus
-          (evt.code === 'Space' && !isCursorVisible_))
+        evt.type === 'keydown'
       ) {
         doc().postKeyEvent(KEY_DOWN, rawCharCode, vclCode);
         return evt.preventDefault();


### PR DESCRIPTION
The original condition was blocking any modifier + shift keys unless space was pressed.
This doesn't seem correct, and was blocking any MOD+Shift accelerators.
Did some testing and space (scroll down) and shift+space (scroll up) when document not focused worked correctly.
