### PR TITLE
Fix getCommandValues: TrackChanges, PageSize, PageMargin [MACRO-2502]

### DIFF
--- a/libreoffice-core/desktop/source/app/main_wasm.cxx
+++ b/libreoffice-core/desktop/source/app/main_wasm.cxx
@@ -439,7 +439,9 @@ public:
         {
             return val(ext->getPageOrientation());
         }
-        return val::u8string(doc_->getCommandValues(command.c_str()));
+
+        const char* result = doc_->getCommandValues(command.c_str());
+        return val::u8string(result);
     }
 
     void subscribe(int viewId, int type)

--- a/libreoffice-core/desktop/source/app/main_wasm.cxx
+++ b/libreoffice-core/desktop/source/app/main_wasm.cxx
@@ -439,7 +439,6 @@ public:
         {
             return val(ext->getPageOrientation());
         }
-
         return val::u8string(doc_->getCommandValues(command.c_str()));
     }
 

--- a/libreoffice-core/desktop/source/app/main_wasm.cxx
+++ b/libreoffice-core/desktop/source/app/main_wasm.cxx
@@ -440,8 +440,7 @@ public:
             return val(ext->getPageOrientation());
         }
 
-        const char* result = doc_->getCommandValues(command.c_str());
-        return val::u8string(result);
+        return val::u8string(doc_->getCommandValues(command.c_str()));
     }
 
     void subscribe(int viewId, int type)

--- a/libreoffice-core/desktop/source/lib/init.cxx
+++ b/libreoffice-core/desktop/source/lib/init.cxx
@@ -6962,12 +6962,6 @@ static char* doc_getCommandValues(LibreOfficeKitDocument* pThis, const char* pCo
     {
         return getTrackedChanges(pThis);
     }
-    // MACRO: {
-    else if (aCommand == ".uno:ViewTrackChangesInformation")
-    {
-        return getTrackedChanges(pThis);
-    }
-    // MACRO: }
     else if (aCommand == ".uno:TrackedChangeAuthors")
     {
         return getTrackedChangeAuthors(pThis);

--- a/libreoffice-core/desktop/source/lib/init.cxx
+++ b/libreoffice-core/desktop/source/lib/init.cxx
@@ -6025,7 +6025,7 @@ static char* getPageSize()
     aJson.put("Width", pPageSizeItem->GetSize().Width());
     aJson.put("Height", pPageSizeItem->GetSize().Height());
 
-    return const_cast<char*>(aJson.finishAndGetAsOString().getStr());
+    return convertOString(aJson.finishAndGetAsOString());
 }
 
 static char* getPageMargins()
@@ -6033,6 +6033,7 @@ static char* getPageMargins()
     tools::JsonWriter aJson;
 
     SfxViewFrame* pViewFrm = SfxViewFrame::Current();
+
 
     if (!pViewFrm) {
         return nullptr;
@@ -6054,7 +6055,7 @@ static char* getPageMargins()
     aJson.put("PageTop", pPageULMarginItem->GetUpper());
     aJson.put("PageBottom", pPageULMarginItem->GetLower());
 
-    return const_cast<char*>(aJson.finishAndGetAsOString().getStr());
+    return convertOString(aJson.finishAndGetAsOString());
 }
 // MACRO: }
 
@@ -6962,7 +6963,12 @@ static char* doc_getCommandValues(LibreOfficeKitDocument* pThis, const char* pCo
     {
         return getTrackedChanges(pThis);
     }
-
+    // MACRO: {
+    else if (aCommand == ".uno:ViewTrackChangesInformation")
+    {
+        return getTrackedChanges(pThis);
+    }
+    // MACRO: }
     else if (aCommand == ".uno:TrackedChangeAuthors")
     {
         return getTrackedChangeAuthors(pThis);

--- a/libreoffice-core/desktop/source/lib/init.cxx
+++ b/libreoffice-core/desktop/source/lib/init.cxx
@@ -6034,7 +6034,6 @@ static char* getPageMargins()
 
     SfxViewFrame* pViewFrm = SfxViewFrame::Current();
 
-
     if (!pViewFrm) {
         return nullptr;
     }

--- a/libreoffice-core/desktop/source/lib/wasm_extensions.cxx
+++ b/libreoffice-core/desktop/source/lib/wasm_extensions.cxx
@@ -140,7 +140,7 @@ std::string WasmDocumentExtension::getPageColor()
         return nullptr;
     }
 
-    static constexpr std::string_view defaultColorHex = "\"#ffffff\"";
+    static constexpr std::string_view defaultColorHex = "#ffffff";
 
 
     SfxPoolItemHolder pState;
@@ -151,7 +151,7 @@ std::string WasmDocumentExtension::getPageColor()
     if (pState.getItem())
     {
         XColorItem* pColor = static_cast<XColorItem*>(pState.getItem()->Clone());
-        OUString aColorHex = u"\"" + pColor->GetColorValue().AsRGBHEXString() + u"\"";
+        OUString aColorHex = pColor->GetColorValue().AsRGBHEXString();
         return OUStringToString(aColorHex);
     }
     return std::string (defaultColorHex);
@@ -171,7 +171,7 @@ std::string WasmDocumentExtension::getPageOrientation ()
 
     bool bIsLandscape = (pSize->GetSize().Width() >= pSize->GetSize().Height());
 
-    return bIsLandscape ? "\"landscape\"" : "\"portrait\"";
+    return bIsLandscape ? "landscape" : "portrait";
 }
 
 }


### PR DESCRIPTION
- adds the missing `.uno:ViewTrackChangesInformation` command Value expected by the monorepo.
- safer string access, previous was causing undefined behavior. 
- removes extra quotes from orientation and page color
