### PR TITLE
RM duplicated toggle orientation

### DIFF
--- a/libreoffice-core/desktop/source/lib/init.cxx
+++ b/libreoffice-core/desktop/source/lib/init.cxx
@@ -5600,12 +5600,6 @@ static void doc_postUnoCommand(LibreOfficeKitDocument* pThis, const char* pComma
 
 
     // MACRO: page setup commands {
-    if (gImpl && aCommand == ".uno:ToggleOrientation")
-    {
-        ExecuteOrientationChange();
-        return;
-    }
-
     if (gImpl && aCommand == ".uno:SetPageSize")
     {
         long width;


### PR DESCRIPTION
this is a duplicate that calls the wrong method, further down the right one calls `toggleOrientation`