### PR TITLE
[MACRO-2576] Add ability to get redline textRange

### DIFF
--- a/libreoffice-core/desktop/source/app/main_wasm.cxx
+++ b/libreoffice-core/desktop/source/app/main_wasm.cxx
@@ -633,6 +633,11 @@ public:
     val gotoOutline(int idx) { return writer()->gotoOutline(idx); }
     void setAuthor(std::string author) { doc_->setAuthor(author.c_str()); }
 
+    val getRedlineTextRange(int redlineId)
+    {
+        return writer()->getRedlineTextRange(redlineId);
+    }
+
 private:
     struct DocWithId
     {
@@ -771,5 +776,6 @@ EMSCRIPTEN_BINDINGS(lok)
         .function("gotoOutline", &DocumentClient::gotoOutline)
         .function("getOutline", &DocumentClient::getOutline)
         .function("setAuthor", &DocumentClient::setAuthor)
-        .function("newView", &DocumentClient::newView);
+        .function("newView", &DocumentClient::newView)
+        .function("getRedlineTextRange", &DocumentClient::getRedlineTextRange);
 }

--- a/libreoffice-core/desktop/wasm/shared.d.ts
+++ b/libreoffice-core/desktop/wasm/shared.d.ts
@@ -175,6 +175,8 @@ export type DocumentWithViewMethods = {
   gotoOutline(index: number): RectArray;
 
   setAuthor(author: string): void;
+
+  getRedlineTextRange(id: number): RectArray[] | undefined;
 };
 
 /** methods that forward to a class weakly bound to the Document that forwards calls */

--- a/libreoffice-core/desktop/wasm/soffice.d.ts
+++ b/libreoffice-core/desktop/wasm/soffice.d.ts
@@ -244,6 +244,8 @@ export declare class Document {
   getOutline(): OutlineItem[];
   gotoOutline(index: number): RectArray;
   setAuthor(author: string): void;
+
+  getRedlineTextRange(id: number): RectArray[] | undefined;
 }
 
 // NOTE: Disabled until unoembind startup cost is under 1s

--- a/libreoffice-core/desktop/wasm/worker.ts
+++ b/libreoffice-core/desktop/wasm/worker.ts
@@ -575,6 +575,11 @@ const handler: DocumentMethodHandler<Document> = {
     doc.setCurrentView(viewId);
     doc.updateComment(id, text);
   },
+
+  getRedlineTextRange: function (doc: Document, viewId: ViewId, id: number) {
+    doc.setCurrentView(viewId);
+    return doc.getRedlineTextRange(id);
+  }
 };
 
 const forwarding: ForwardingMethodHandlers<Document> = {

--- a/libreoffice-core/include/wasm/IWriterExtensions.hxx
+++ b/libreoffice-core/include/wasm/IWriterExtensions.hxx
@@ -62,5 +62,6 @@ public:
     virtual val gotoOutline(int /* outlineIndex */) { return {}; };
     virtual void bumpInvalidationGeneration() {};
     virtual sal_uInt32 invalidationGeneration() { return 0; };
+    virtual val getRedlineTextRange(int /* redlineId */) { return {}; };
 };
 }

--- a/libreoffice-core/sw/inc/unotxdoc.hxx
+++ b/libreoffice-core/sw/inc/unotxdoc.hxx
@@ -573,6 +573,7 @@ public:
     _Atomic sal_uInt32 m_nInvalidationGeneration = 0;
     void bumpInvalidationGeneration() override;
     sal_uInt32 invalidationGeneration() override;
+    emscripten::val getRedlineTextRange(int redlineId) override;
     /// MACRO-2313: }
 };
 

--- a/libreoffice-core/sw/source/wasm/extensions.cxx
+++ b/libreoffice-core/sw/source/wasm/extensions.cxx
@@ -391,7 +391,6 @@ val SwXTextDocument::headerFooterRect()
 
 val SwXTextDocument::getRedlineTextRange(int redlineId)
 {
-    SAL_WARN("lok", "getRedlineTextRange is not implemented" << redlineId);
     auto wrtShell = GetDocShell()->GetWrtShell();
     const SwRedlineTable& rRedlineTable = wrtShell->getIDocumentRedlineAccess().GetRedlineTable();
     for (SwRedlineTable::size_type i = 0; i < rRedlineTable.size(); ++i)
@@ -414,7 +413,7 @@ val SwXTextDocument::getRedlineTextRange(int redlineId)
             break;
         }
     }
-    return val::undefined();
+    return {};
 }
 
 namespace

--- a/libreoffice-core/sw/source/wasm/extensions.cxx
+++ b/libreoffice-core/sw/source/wasm/extensions.cxx
@@ -1,3 +1,4 @@
+#include "redline.hxx"
 #include "sal/types.h"
 #include <unordered_set>
 #include <vector>
@@ -386,6 +387,34 @@ val SwXTextDocument::headerFooterRect()
     result.set("type", bInHeader ? val::u8string("header") : val::u8string("footer"));
     result.set("rect", rectToArray(aRect));
     return result;
+}
+
+val SwXTextDocument::getRedlineTextRange(int redlineId)
+{
+    SAL_WARN("lok", "getRedlineTextRange is not implemented" << redlineId);
+    auto wrtShell = GetDocShell()->GetWrtShell();
+    const SwRedlineTable& rRedlineTable = wrtShell->getIDocumentRedlineAccess().GetRedlineTable();
+    for (SwRedlineTable::size_type i = 0; i < rRedlineTable.size(); ++i)
+    {
+        if (redlineId == rRedlineTable[i]->GetId()) {
+            SwRangeRedline* pRedline = rRedlineTable[i];
+            auto [pStartPos, pEndPos] = pRedline->StartEnd(); // SwPosition*
+            SwContentNode* pContentNd = pRedline->GetPointContentNode();
+            if (pContentNd)
+            {
+                SwShellCursor aCursor(*wrtShell, *pStartPos);
+                aCursor.SetMark();
+                *aCursor.GetMark() = *pEndPos;
+                aCursor.FillRects();
+                SwRects* pRects(&aCursor);
+                bottomTwips(pRects);
+                val rects = swRectsToArray(pRects);
+                return rects;
+            }
+            break;
+        }
+    }
+    return val::undefined();
 }
 
 namespace

--- a/qa-env/src/App.tsx
+++ b/qa-env/src/App.tsx
@@ -60,6 +60,13 @@ async function saveAsPDF(doc: DocumentClient | null) {
   downloadFile('Pdf Export.pdf', buffer, 'application/pdf');
 }
 
+async function testTrackChanges(doc: DocumentClient | null) {
+  if (!doc) return;
+  console.log('calling');
+  const result = await doc.getRedlineTextRange(2);
+  console.log('RESULT', result);
+}
+
 const MOD = IS_MAC ? 'cmd' : 'ctrl';
 const ignoredShortcuts: Shortcut[] = [
   {
@@ -140,6 +147,7 @@ function App() {
       <Show when={getDoc()}>
         <div class="h-[70px] border-b border border-gray-300 flex items-center bg-gray-200 px-2">
           <button onClick={() => saveAsPDF(getDoc())}>Save As PDF</button>
+          <button onClick={() => testTrackChanges(getDoc())}>TRACK CHANGES</button>
         </div>
       </Show>
       <Show when={loading()}>

--- a/qa-env/src/App.tsx
+++ b/qa-env/src/App.tsx
@@ -60,13 +60,6 @@ async function saveAsPDF(doc: DocumentClient | null) {
   downloadFile('Pdf Export.pdf', buffer, 'application/pdf');
 }
 
-async function testTrackChanges(doc: DocumentClient | null) {
-  if (!doc) return;
-  console.log('calling');
-  const result = await doc.getRedlineTextRange(2);
-  console.log('RESULT', result);
-}
-
 const MOD = IS_MAC ? 'cmd' : 'ctrl';
 const ignoredShortcuts: Shortcut[] = [
   {
@@ -147,7 +140,6 @@ function App() {
       <Show when={getDoc()}>
         <div class="h-[70px] border-b border border-gray-300 flex items-center bg-gray-200 px-2">
           <button onClick={() => saveAsPDF(getDoc())}>Save As PDF</button>
-          <button onClick={() => testTrackChanges(getDoc())}>TRACK CHANGES</button>
         </div>
       </Show>
       <Show when={loading()}>


### PR DESCRIPTION
Adds in `getRedlineTextRange` method to that allows us to return the current textRange for a given track change id