### PR TITLE
FIX temp fix for interaction handler [MACRO-2700]

### DIFF
--- a/libreoffice-core/desktop/source/lib/lokinteractionhandler.cxx
+++ b/libreoffice-core/desktop/source/lib/lokinteractionhandler.cxx
@@ -413,6 +413,15 @@ sal_Bool SAL_CALL LOKInteractionHandler::handleInteractionRequest(
     uno::Sequence<uno::Reference<task::XInteractionContinuation>> const &rContinuations = xRequest->getContinuations();
     uno::Any const request(xRequest->getRequest());
 
+    // MACRO: MACRO-2700 Always approve broken package requests {
+    document::BrokenPackageRequest aBrokenPackageRequest;
+    if (request >>= aBrokenPackageRequest)
+    {
+        selectApproved(rContinuations);
+        return true;
+    }
+    // MACRO: }
+
     if (handleIOException(rContinuations, request))
         return true;
 


### PR DESCRIPTION
Seems like there has been some kind of regression in the interaction handler since we pulled in our proprietary changes with a fix.

The issue seems isolated to Broken Package Repair requests only.

Since we should auto-approve repair requests anyway, and we don't know if it affects anything else. I don't think its worth spending several hours to a day to try and bisect / fix something that isn't really being used anyway.

Ticket to revisit after august 1st if needed: 
https://www.notion.so/macrocom/Maybe-fix-interaction-handler-c517142a29104d59a6e398c496df2f26


