### PR TITLE
Fix initial cursor in empty doc

### DIFF
--- a/libreoffice-core/desktop/inc/lib/wasm_extensions.hxx
+++ b/libreoffice-core/desktop/inc/lib/wasm_extensions.hxx
@@ -109,7 +109,7 @@ struct DESKTOP_DLLPUBLIC WasmDocumentExtension : public _LibreOfficeKitDocument
     std::vector<std::pair<const std::string, const std::string>> listParts() const;
 
     std::vector<std::pair<std::string, std::string>> save();
-
+    std::optional<std::string> getCursor(int viewId);
 };
 
 struct DESKTOP_DLLPUBLIC WasmOfficeExtension : public _LibreOfficeKit

--- a/libreoffice-core/desktop/source/app/main_wasm.cxx
+++ b/libreoffice-core/desktop/source/app/main_wasm.cxx
@@ -850,6 +850,8 @@ public:
 
     val getRedlineTextRange(int redlineId) { return writer()->getRedlineTextRange(redlineId); }
 
+    std::optional<std::string> getCursor(int viewId) { return ext()->getCursor(viewId); }
+
 private:
     struct DocWithId
     {
@@ -1032,5 +1034,6 @@ EMSCRIPTEN_BINDINGS(lok)
         .function("undo", &DocumentClient::undo)
         .function("redo", &DocumentClient::redo)
         .function("getRedlineTextRange", &DocumentClient::getRedlineTextRange)
+        .function("getCursor", &DocumentClient::getCursor)
         .function("newView", &DocumentClient::newView);
 }

--- a/libreoffice-core/desktop/source/lib/wasm_extensions.cxx
+++ b/libreoffice-core/desktop/source/lib/wasm_extensions.cxx
@@ -368,5 +368,21 @@ std::vector<std::pair<std::string, std::string>>  WasmDocumentExtension::save()
     auto files = comphelper::OStorageHelper::GetExpandedStorageInstance()->getRecentlyChangedFiles();
     return files;
 }
+
+std::optional<std::string> WasmDocumentExtension::getCursor(int viewId)
+{
+    if (SfxViewShell* viewShell
+        = SfxViewShell::GetFirst(false, [viewId](const SfxViewShell* shell)
+                                 { return shell->GetViewShellId().get() == viewId; }))
+    {
+        std::optional<OString> payload
+            = viewShell->getLOKPayload(LOK_CALLBACK_INVALIDATE_VISIBLE_CURSOR, viewId);
+        if (payload)
+        {
+            return std::string(static_cast<std::string_view>(*payload));
+        }
+    }
+    return {};
 }
 
+}

--- a/libreoffice-core/desktop/wasm/shared.d.ts
+++ b/libreoffice-core/desktop/wasm/shared.d.ts
@@ -189,6 +189,7 @@ export type DocumentWithViewMethods = {
   getExpandedPart(path: string): {path: string, content: ArrayBuffer} | null;
   listExpandedParts(): Array<{path: string, sha: string}>;
   getRedlineTextRange(id: number): RectArray[] | undefined;
+  getCursor(): string | undefined;
 };
 
 /** methods that forward to a class weakly bound to the Document that forwards calls */

--- a/libreoffice-core/desktop/wasm/soffice.d.ts
+++ b/libreoffice-core/desktop/wasm/soffice.d.ts
@@ -271,6 +271,8 @@ export declare class Document {
   redo(count: number): void;
 
   getRedlineTextRange(id: number): RectArray[] | undefined;
+
+  getCursor(viewId: number): string | undefined;
 }
 
 // NOTE: Disabled until unoembind startup cost is under 1s

--- a/libreoffice-core/desktop/wasm/worker.ts
+++ b/libreoffice-core/desktop/wasm/worker.ts
@@ -639,7 +639,11 @@ const handler: DocumentMethodHandler<Document> = {
   getRedlineTextRange: function (doc: Document, viewId: ViewId, id: number) {
     doc.setCurrentView(viewId);
     return doc.getRedlineTextRange(id);
-  }
+  },
+
+  getCursor: function (doc: Document, viewId: ViewId) {
+    return doc.getCursor(viewId);
+  },
 };
 
 const forwarding: ForwardingMethodHandlers<Document> = {

--- a/qa-env/src/OfficeDocument/docEventSignal.ts
+++ b/qa-env/src/OfficeDocument/docEventSignal.ts
@@ -47,9 +47,15 @@ export function createInitalizedDocEventSignal<T>(
   doc: Accessor<DocumentClient>,
   type: CallbackType,
   transform: (payload: string) => T | undefined,
-  initial: Exclude<T, Function>
+  initial: Exclude<T, Function> | Promise<Exclude<T, Function>>
 ): Accessor<T> {
-  const [payload, setPayload] = createSignal<T>(initial);
+  const [payload, setPayload] =
+    initial instanceof Promise
+      ? createSignal<T>(undefined as T)
+      : createSignal<T>(initial);
+  if (initial instanceof Promise) {
+    initial.then(setPayload);
+  }
   const callback = frameThrottle(
     transform
       ? (payload: string) => {


### PR DESCRIPTION
This empty doc should now have a cursor in the QA env:

[blank.docx](https://github.com/user-attachments/files/16193903/blank.docx)

Not worth cutting a version just yet, think we'll have the expanded parts fixes in shortly after this