### PR TITLE
[MACRO-2286] - Editor QoL Checkboxes

### DIFF
--- a/emsdk-patches/002-vite_compilation_fix.patch
+++ b/emsdk-patches/002-vite_compilation_fix.patch
@@ -1,0 +1,27 @@
+diff --git a/./upstream/emscripten/tools/file_packager.orig.py b/./upstream/emscripten/tools/file_packager.py
+
+--- emsdk/upstream/emscripten/tools/file_packager.orig.py
++++ emsdk/upstream/emscripten/tools/file_packager.py
+@@ -768,12 +768,11 @@
+         PACKAGE_PATH = encodeURIComponent(location.pathname.toString().substring(0, location.pathname.toString().lastIndexOf('/')) + '/');
+       }
+       var PACKAGE_NAME = '%s';
+-      var REMOTE_PACKAGE_BASE = '%s';
+       if (typeof Module['locateFilePackage'] === 'function' && !Module['locateFile']) {
+         Module['locateFile'] = Module['locateFilePackage'];
+         err('warning: you defined Module.locateFilePackage, that has been renamed to Module.locateFile (using your locateFilePackage for now)');
+       }
+-      var REMOTE_PACKAGE_NAME = Module['locateFile'] ? Module['locateFile'](REMOTE_PACKAGE_BASE, '') : REMOTE_PACKAGE_BASE;\n''' % (js_manipulation.escape_for_js_string(remote_package_name), js_manipulation.escape_for_js_string(remote_package_name))
++      var REMOTE_PACKAGE_NAME = new URL('./%s', import.meta.url).href;\n''' % (js_manipulation.escape_for_js_string(remote_package_name), js_manipulation.escape_for_js_string(remote_package_name))
+     metadata['remote_package_size'] = remote_package_size
+     ret += '''var REMOTE_PACKAGE_SIZE = metadata['remote_package_size'];\n'''
+ 
+@@ -1112,7 +1111,7 @@
+ 
+   function runMetaWithFS() {
+     Module['addRunDependency']('%(metadata_file)s');
+-    var REMOTE_METADATA_NAME = Module['locateFile'] ? Module['locateFile']('%(metadata_file)s', '') : '%(metadata_file)s';
++    var REMOTE_METADATA_NAME = new URL('./%(metadata_file)s', import.meta.url).href;
+     var xhr = new XMLHttpRequest();
+     xhr.onreadystatechange = function() {
+      if (xhr.readyState === 4 && xhr.status === 200) {

--- a/libreoffice-core/sw/inc/IDocumentContentOperations.hxx
+++ b/libreoffice-core/sw/inc/IDocumentContentOperations.hxx
@@ -205,7 +205,9 @@ public:
         const SwPaM &rRg, const OUString& rObjName, sal_Int64 nAspect,
         const SfxItemSet* pFlyAttrSet, const SfxItemSet* pGrfAttrSet) = 0;
 
+    // MACRO-2286: Check if paragraph starts with checkbox
     virtual bool NodeStartsWithCheckbox(const SwPosition &rPos) = 0;
+    // MACRO-2286
 
     /** Split a node at rPos (implemented only for TextNode).
     */

--- a/libreoffice-core/sw/inc/IDocumentContentOperations.hxx
+++ b/libreoffice-core/sw/inc/IDocumentContentOperations.hxx
@@ -205,6 +205,8 @@ public:
         const SwPaM &rRg, const OUString& rObjName, sal_Int64 nAspect,
         const SfxItemSet* pFlyAttrSet, const SfxItemSet* pGrfAttrSet) = 0;
 
+    virtual bool NodeStartsWithCheckbox(const SwPosition &rPos) = 0;
+
     /** Split a node at rPos (implemented only for TextNode).
     */
     virtual bool SplitNode(const SwPosition &rPos, bool bChkTableStart) = 0;

--- a/libreoffice-core/sw/source/core/doc/DocumentContentOperationsManager.cxx
+++ b/libreoffice-core/sw/source/core/doc/DocumentContentOperationsManager.cxx
@@ -92,6 +92,7 @@
 #include <com/sun/star/i18n/WordType.hpp>
 #include <com/sun/star/i18n/XBreakIterator.hpp>
 #include <com/sun/star/embed/XEmbeddedObject.hpp>
+#include <xmloff/odffields.hxx>
 
 #include <tuple>
 #include <memory>
@@ -3419,6 +3420,23 @@ SwDrawFrameFormat* DocumentContentOperationsManager::InsertDrawObj(
 
     m_rDoc.getIDocumentState().SetModified();
     return pFormat;
+}
+
+bool DocumentContentOperationsManager::NodeStartsWithCheckbox( const SwPosition &rPos) {
+    IDocumentMarkAccess* pMarksAccess = m_rDoc.getIDocumentMarkAccess();    
+    SwTextNode* pTextNode = rPos.GetNode().GetTextNode();
+
+    SwPosition pos(*pTextNode, 0);
+    sw::mark::IFieldmark* pFieldBookmark = pMarksAccess->getInnerFieldmarkFor(pos);
+    if (pFieldBookmark && pFieldBookmark->GetFieldname() == ODF_FORMCHECKBOX)
+        return true;
+
+    pos = SwPosition(*pTextNode, 1);
+    pFieldBookmark = pMarksAccess->getInnerFieldmarkFor(pos);
+    if (pFieldBookmark && pFieldBookmark->GetFieldname() == ODF_FORMCHECKBOX)
+        return true;
+
+    return false;
 }
 
 bool DocumentContentOperationsManager::SplitNode( const SwPosition &rPos, bool bChkTableStart )

--- a/libreoffice-core/sw/source/core/doc/DocumentContentOperationsManager.cxx
+++ b/libreoffice-core/sw/source/core/doc/DocumentContentOperationsManager.cxx
@@ -3422,7 +3422,7 @@ SwDrawFrameFormat* DocumentContentOperationsManager::InsertDrawObj(
     return pFormat;
 }
 
-// MACRO-2286: Check if paragraph starts with checkbox
+// MACRO-2286: Check if paragraph starts with checkbox {
 bool DocumentContentOperationsManager::NodeStartsWithCheckbox( const SwPosition &rPos) {
     IDocumentMarkAccess* pMarksAccess = m_rDoc.getIDocumentMarkAccess();    
     SwTextNode* pTextNode = rPos.GetNode().GetTextNode();
@@ -3441,7 +3441,7 @@ bool DocumentContentOperationsManager::NodeStartsWithCheckbox( const SwPosition 
 
     return false;
 }
-// MACRO-2286
+// MACRO-2286 }
 
 bool DocumentContentOperationsManager::SplitNode( const SwPosition &rPos, bool bChkTableStart )
 {

--- a/libreoffice-core/sw/source/core/doc/DocumentContentOperationsManager.cxx
+++ b/libreoffice-core/sw/source/core/doc/DocumentContentOperationsManager.cxx
@@ -3422,9 +3422,12 @@ SwDrawFrameFormat* DocumentContentOperationsManager::InsertDrawObj(
     return pFormat;
 }
 
+// MACRO-2286: Check if paragraph starts with checkbox
 bool DocumentContentOperationsManager::NodeStartsWithCheckbox( const SwPosition &rPos) {
     IDocumentMarkAccess* pMarksAccess = m_rDoc.getIDocumentMarkAccess();    
     SwTextNode* pTextNode = rPos.GetNode().GetTextNode();
+    if(nullptr == pTextNode)
+        return false;
 
     SwPosition pos(*pTextNode, 0);
     sw::mark::IFieldmark* pFieldBookmark = pMarksAccess->getInnerFieldmarkFor(pos);
@@ -3438,6 +3441,7 @@ bool DocumentContentOperationsManager::NodeStartsWithCheckbox( const SwPosition 
 
     return false;
 }
+// MACRO-2286
 
 bool DocumentContentOperationsManager::SplitNode( const SwPosition &rPos, bool bChkTableStart )
 {

--- a/libreoffice-core/sw/source/core/edit/editsh.cxx
+++ b/libreoffice-core/sw/source/core/edit/editsh.cxx
@@ -184,8 +184,13 @@ void SwEditShell::SplitNode( bool bAutoFormat, bool bCheckTableStart )
 {
     StartAllAction();
     GetDoc()->GetIDocumentUndoRedo().StartUndo(SwUndoId::EMPTY, nullptr);
+
+    // MACRO-2286: Check if paragraph starts with checkbox
+    bool hasCheckbox = false;
     SwPaM* pCursorPos = GetCursor();
-    bool hasCheckbox = GetDoc()->getIDocumentContentOperations().NodeStartsWithCheckbox(*pCursorPos->GetPoint());
+    if(nullptr != pCursorPos && nullptr != pCursorPos->GetPoint())
+        hasCheckbox = GetDoc()->getIDocumentContentOperations().NodeStartsWithCheckbox(*pCursorPos->GetPoint());
+    // MACRO-2286
 
     for(SwPaM& rPaM : GetCursor()->GetRingContainer())
     {
@@ -194,23 +199,26 @@ void SwEditShell::SplitNode( bool bAutoFormat, bool bCheckTableStart )
         GetDoc()->getIDocumentContentOperations().SplitNode( *rPaM.GetPoint(), bCheckTableStart );
     }
 
-    // Insert a checkbox at the start of the new paragraph
+    // MACRO-2286: Insert a checkbox at the start of the new paragraph
     if (hasCheckbox) {
         GetDoc()->getIDocumentContentOperations().InsertString( *pCursorPos, "\t");
         GetDoc()->getIDocumentMarkAccess()->makeNoTextFieldBookmark(*pCursorPos, OUString(), ODF_FORMCHECKBOX);
         GetDoc()->getIDocumentContentOperations().InsertString( *pCursorPos, " ");
     }
+    // MACRO-2286
 
     GetDoc()->GetIDocumentUndoRedo().EndUndo(SwUndoId::EMPTY, nullptr);
 
     if( bAutoFormat )
         AutoFormatBySplitNode();
 
+    // MACRO-2286: Move Cursor to after the checkbox
     if (hasCheckbox) {
         pCursorPos->Move();
         pCursorPos->Move();
         pCursorPos->Move();
     }
+    // MACRO-2286
 
     ClearTableBoxContent();
 

--- a/libreoffice-core/sw/source/core/edit/editsh.cxx
+++ b/libreoffice-core/sw/source/core/edit/editsh.cxx
@@ -185,12 +185,12 @@ void SwEditShell::SplitNode( bool bAutoFormat, bool bCheckTableStart )
     StartAllAction();
     GetDoc()->GetIDocumentUndoRedo().StartUndo(SwUndoId::EMPTY, nullptr);
 
-    // MACRO-2286: Check if paragraph starts with checkbox
+    // MACRO-2286: Check if paragraph starts with checkbox {
     bool hasCheckbox = false;
     SwPaM* pCursorPos = GetCursor();
     if(nullptr != pCursorPos && nullptr != pCursorPos->GetPoint())
         hasCheckbox = GetDoc()->getIDocumentContentOperations().NodeStartsWithCheckbox(*pCursorPos->GetPoint());
-    // MACRO-2286
+    // MACRO-2286 }
 
     for(SwPaM& rPaM : GetCursor()->GetRingContainer())
     {
@@ -199,26 +199,26 @@ void SwEditShell::SplitNode( bool bAutoFormat, bool bCheckTableStart )
         GetDoc()->getIDocumentContentOperations().SplitNode( *rPaM.GetPoint(), bCheckTableStart );
     }
 
-    // MACRO-2286: Insert a checkbox at the start of the new paragraph
+    // MACRO-2286: Insert a checkbox at the start of the new paragraph {
     if (hasCheckbox) {
         GetDoc()->getIDocumentContentOperations().InsertString( *pCursorPos, "\t");
         GetDoc()->getIDocumentMarkAccess()->makeNoTextFieldBookmark(*pCursorPos, OUString(), ODF_FORMCHECKBOX);
         GetDoc()->getIDocumentContentOperations().InsertString( *pCursorPos, " ");
     }
-    // MACRO-2286
+    // MACRO-2286 }
 
     GetDoc()->GetIDocumentUndoRedo().EndUndo(SwUndoId::EMPTY, nullptr);
 
     if( bAutoFormat )
         AutoFormatBySplitNode();
 
-    // MACRO-2286: Move Cursor to after the checkbox
+    // MACRO-2286: Move Cursor to after the checkbox {
     if (hasCheckbox) {
         pCursorPos->Move();
         pCursorPos->Move();
         pCursorPos->Move();
     }
-    // MACRO-2286
+    // MACRO-2286 }
 
     ClearTableBoxContent();
 

--- a/libreoffice-core/sw/source/core/edit/editsh.cxx
+++ b/libreoffice-core/sw/source/core/edit/editsh.cxx
@@ -56,6 +56,7 @@
 #include <SwNodeNum.hxx>
 #include <unocrsr.hxx>
 #include <calbck.hxx>
+#include <xmloff/odffields.hxx>
 
 using namespace com::sun::star;
 
@@ -183,6 +184,8 @@ void SwEditShell::SplitNode( bool bAutoFormat, bool bCheckTableStart )
 {
     StartAllAction();
     GetDoc()->GetIDocumentUndoRedo().StartUndo(SwUndoId::EMPTY, nullptr);
+    SwPaM* pCursorPos = GetCursor();
+    bool hasCheckbox = GetDoc()->getIDocumentContentOperations().NodeStartsWithCheckbox(*pCursorPos->GetPoint());
 
     for(SwPaM& rPaM : GetCursor()->GetRingContainer())
     {
@@ -191,10 +194,23 @@ void SwEditShell::SplitNode( bool bAutoFormat, bool bCheckTableStart )
         GetDoc()->getIDocumentContentOperations().SplitNode( *rPaM.GetPoint(), bCheckTableStart );
     }
 
+    // Insert a checkbox at the start of the new paragraph
+    if (hasCheckbox) {
+        GetDoc()->getIDocumentContentOperations().InsertString( *pCursorPos, "\t");
+        GetDoc()->getIDocumentMarkAccess()->makeNoTextFieldBookmark(*pCursorPos, OUString(), ODF_FORMCHECKBOX);
+        GetDoc()->getIDocumentContentOperations().InsertString( *pCursorPos, " ");
+    }
+
     GetDoc()->GetIDocumentUndoRedo().EndUndo(SwUndoId::EMPTY, nullptr);
 
     if( bAutoFormat )
         AutoFormatBySplitNode();
+
+    if (hasCheckbox) {
+        pCursorPos->Move();
+        pCursorPos->Move();
+        pCursorPos->Move();
+    }
 
     ClearTableBoxContent();
 

--- a/libreoffice-core/sw/source/core/inc/DocumentContentOperationsManager.hxx
+++ b/libreoffice-core/sw/source/core/inc/DocumentContentOperationsManager.hxx
@@ -75,9 +75,9 @@ public:
     SwFlyFrameFormat* InsertOLE(const SwPaM &rRg, const OUString& rObjName, sal_Int64 nAspect, const SfxItemSet* pFlyAttrSet,
                            const SfxItemSet* pGrfAttrSet) override;
 
-    // MACRO-2286: Check if paragraph starts with checkbox
+    // MACRO-2286: Check if paragraph starts with checkbox {
     bool NodeStartsWithCheckbox(const SwPosition &rPos) override;
-    // MACRO-2286
+    // MACRO-2286 }
 
     bool SplitNode(const SwPosition &rPos, bool bChkTableStart) override;
 

--- a/libreoffice-core/sw/source/core/inc/DocumentContentOperationsManager.hxx
+++ b/libreoffice-core/sw/source/core/inc/DocumentContentOperationsManager.hxx
@@ -75,6 +75,8 @@ public:
     SwFlyFrameFormat* InsertOLE(const SwPaM &rRg, const OUString& rObjName, sal_Int64 nAspect, const SfxItemSet* pFlyAttrSet,
                            const SfxItemSet* pGrfAttrSet) override;
 
+    bool NodeStartsWithCheckbox(const SwPosition &rPos) override;
+
     bool SplitNode(const SwPosition &rPos, bool bChkTableStart) override;
 
     bool AppendTextNode(SwPosition& rPos) override;

--- a/libreoffice-core/sw/source/core/inc/DocumentContentOperationsManager.hxx
+++ b/libreoffice-core/sw/source/core/inc/DocumentContentOperationsManager.hxx
@@ -75,7 +75,9 @@ public:
     SwFlyFrameFormat* InsertOLE(const SwPaM &rRg, const OUString& rObjName, sal_Int64 nAspect, const SfxItemSet* pFlyAttrSet,
                            const SfxItemSet* pGrfAttrSet) override;
 
+    // MACRO-2286: Check if paragraph starts with checkbox
     bool NodeStartsWithCheckbox(const SwPosition &rPos) override;
+    // MACRO-2286
 
     bool SplitNode(const SwPosition &rPos, bool bChkTableStart) override;
 

--- a/libreoffice-core/sw/source/uibase/docvw/edtwin.cxx
+++ b/libreoffice-core/sw/source/uibase/docvw/edtwin.cxx
@@ -567,8 +567,10 @@ void SwEditWin::UpdatePointer(const Point &rLPt, sal_uInt16 nModifier )
                     IsAttrAtPos::ClickField |
                     IsAttrAtPos::InetAttr |
                     IsAttrAtPos::Ftn |
+                    // MACRO-2286: Check if hovering over Checkbox
                     IsAttrAtPos::SmartTag | 
                     IsAttrAtPos::FormControl);
+                    // MACRO-2286
                 if( rSh.GetContentAtPos( rLPt, aSwContentAtPos) )
                 {
                     // Is edit inline input field
@@ -580,6 +582,7 @@ void SwEditWin::UpdatePointer(const Point &rLPt, sal_uInt16 nModifier )
                         if (!(pCursorField && pCursorField == aSwContentAtPos.pFndTextAttr->GetFormatField().GetField()))
                             eStyle = PointerStyle::RefHand;
                     }
+                    // MACRO-2286: Check if hovering over Checkbox
                     else if (IsAttrAtPos::FormControl == aSwContentAtPos.eContentAtPos) {
                         if (aSwContentAtPos.aFnd.pFieldmark != nullptr) {
                             IFieldmark *fieldBM = const_cast<IFieldmark*> (aSwContentAtPos.aFnd.pFieldmark);
@@ -587,6 +590,7 @@ void SwEditWin::UpdatePointer(const Point &rLPt, sal_uInt16 nModifier )
                                 eStyle = PointerStyle::RefHand;
                         }
                     }
+                    // MACRO-2286
                     else
                     {
                         const bool bClickToFollow = IsAttrAtPos::InetAttr == aSwContentAtPos.eContentAtPos ||

--- a/libreoffice-core/sw/source/uibase/docvw/edtwin.cxx
+++ b/libreoffice-core/sw/source/uibase/docvw/edtwin.cxx
@@ -567,7 +567,8 @@ void SwEditWin::UpdatePointer(const Point &rLPt, sal_uInt16 nModifier )
                     IsAttrAtPos::ClickField |
                     IsAttrAtPos::InetAttr |
                     IsAttrAtPos::Ftn |
-                    IsAttrAtPos::SmartTag);
+                    IsAttrAtPos::SmartTag | 
+                    IsAttrAtPos::FormControl);
                 if( rSh.GetContentAtPos( rLPt, aSwContentAtPos) )
                 {
                     // Is edit inline input field
@@ -578,6 +579,13 @@ void SwEditWin::UpdatePointer(const Point &rLPt, sal_uInt16 nModifier )
                         const SwField *pCursorField = rSh.CursorInsideInputField() ? rSh.GetCurField( true ) : nullptr;
                         if (!(pCursorField && pCursorField == aSwContentAtPos.pFndTextAttr->GetFormatField().GetField()))
                             eStyle = PointerStyle::RefHand;
+                    }
+                    else if (IsAttrAtPos::FormControl == aSwContentAtPos.eContentAtPos) {
+                        if (aSwContentAtPos.aFnd.pFieldmark != nullptr) {
+                            IFieldmark *fieldBM = const_cast<IFieldmark*> (aSwContentAtPos.aFnd.pFieldmark);
+                            if (fieldBM->GetFieldname() == ODF_FORMCHECKBOX)
+                                eStyle = PointerStyle::RefHand;
+                        }
                     }
                     else
                     {

--- a/libreoffice-core/sw/source/uibase/docvw/edtwin.cxx
+++ b/libreoffice-core/sw/source/uibase/docvw/edtwin.cxx
@@ -567,10 +567,10 @@ void SwEditWin::UpdatePointer(const Point &rLPt, sal_uInt16 nModifier )
                     IsAttrAtPos::ClickField |
                     IsAttrAtPos::InetAttr |
                     IsAttrAtPos::Ftn |
-                    // MACRO-2286: Check if hovering over Checkbox
+                    // MACRO-2286: Check if hovering over Checkbox {
                     IsAttrAtPos::SmartTag | 
                     IsAttrAtPos::FormControl);
-                    // MACRO-2286
+                    // MACRO-2286 }
                 if( rSh.GetContentAtPos( rLPt, aSwContentAtPos) )
                 {
                     // Is edit inline input field
@@ -582,7 +582,7 @@ void SwEditWin::UpdatePointer(const Point &rLPt, sal_uInt16 nModifier )
                         if (!(pCursorField && pCursorField == aSwContentAtPos.pFndTextAttr->GetFormatField().GetField()))
                             eStyle = PointerStyle::RefHand;
                     }
-                    // MACRO-2286: Check if hovering over Checkbox
+                    // MACRO-2286: Check if hovering over Checkbox {
                     else if (IsAttrAtPos::FormControl == aSwContentAtPos.eContentAtPos) {
                         if (aSwContentAtPos.aFnd.pFieldmark != nullptr) {
                             IFieldmark *fieldBM = const_cast<IFieldmark*> (aSwContentAtPos.aFnd.pFieldmark);
@@ -590,7 +590,7 @@ void SwEditWin::UpdatePointer(const Point &rLPt, sal_uInt16 nModifier )
                                 eStyle = PointerStyle::RefHand;
                         }
                     }
-                    // MACRO-2286
+                    // MACRO-2286 }
                     else
                     {
                         const bool bClickToFollow = IsAttrAtPos::InetAttr == aSwContentAtPos.eContentAtPos ||


### PR DESCRIPTION
## Summary
A few QoL improvements regarding checkboxes in the Editor

- Pressing enter in the same line of a checkbox inserts a checkbox in the next line
- Hovering over a checkbox changes the cursor to a selector cursor

## Screenshots, GIFs, and Videos

https://www.loom.com/share/fd3d8eef98604e8a942eec3536517c0b

## Checklist
- [X] Included (`MACRO-N`) in the PR title.
- [X] QA'd

Tests for PR (pick one):
   - [ ] N/A
   - [ ] 🐌 Manual testing (https://docs.google.com/spreadsheets/d/1Ysh9C4w3teCYTDRg4dV0CHf885IXvMhyDyCYFjVW9qA)
   - [ ] 🤖 Automated
     - I can add automated playwright tests in app monorepo to make sure the checkbox shows up when enter is clicked after this PR is merged
